### PR TITLE
Merge Develop. Version bumped from (1, 6, 3) to (1, 6, 4) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
-**__pycache__/
+__pycache__/
 data/
 tags/
-**.cfg
-**.log
-**.backup
-**.BACKUP
+*.cfg
+*.log
+*.backup

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+**__pycache__/
+data/
+tags/
+**.cfg
+**.log
+**.backup
+**.BACKUP

--- a/.hgignore
+++ b/.hgignore
@@ -1,8 +1,0 @@
-syntax: glob
-*__pycache__/*
-data/*
-tags/*
-*.cfg
-*.log
-*.backup
-*.BACKUP

--- a/__init__.py
+++ b/__init__.py
@@ -3,5 +3,5 @@
 # ##############
 __author__ = "Devin Bobadilla"
 #           YYYY.MM.DD
-__date__ = "2019.08.14"
-__version__ = (1, 6, 3)
+__date__ = "2019.09.05"
+__version__ = (1, 6, 4)

--- a/windows/tools/bitmap_converter_window.py
+++ b/windows/tools/bitmap_converter_window.py
@@ -324,7 +324,8 @@ def convert_bitmap_tag(tag, conv_flags, bitmap_info):
 
             if success:
                 tex_root = pixel_data[i]
-                tex_root.parse(initdata=arb.texture_block)
+                tex_root.parse(initdata=arb.texture_block,
+                               clear=False, init_attrs=False)
                 tag.swizzled(i, arb.swizzled)
 
                 #change the bitmap format to the new format

--- a/windows/tools/data_extraction_window.py
+++ b/windows/tools/data_extraction_window.py
@@ -58,7 +58,9 @@ class DataExtractionWindow(tk.Toplevel, BinillaWidget):
             except Exception:
                 pass
 
-        self.listbox_index_to_def_id = list(sorted(self.tag_data_extractors.keys()))
+        self.listbox_index_to_def_id = list(sorted(
+            k for k in self.tag_data_extractors.keys()
+            if k in self.tag_class_fcc_to_ext))
 
         # make the tkinter variables
         self.dir_path = tk.StringVar(self, self.handler.tagsdir)


### PR DESCRIPTION
Fixed bug with tag data extractor window. Selected classes of tags were sometimes off-shifted, so the wrong class would get extracted.
Fixed exception in bitmap converter window caused by pixel arrays being initialized to None before converted pixel data could be parsed into them.