### PR TITLE
Fix missing LICENSE in setup package_data

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This project also inherits changes from [Binilla](https://github.com/Sigmmma/binilla).
 
+## [Unreleased]
+### Changed
+ - Fix missing license in distributions.
+
 ## [1.9.0]
 ### Added
  - Added \_\_main\_\_ so Mozzarilla can be executed using `python -m mozzarilla` or just `mozzarilla` on some systems.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     package_data={
         'mozzarilla': [
             'styles/*.*', '*.[tT][xX][tT]', '*.MD', '*.pyw', '*.ico', '*.png',
-            'msg.dat',
+            'msg.dat','LICENSE',
             ]
         },
     platforms=["POSIX", "Windows"],


### PR DESCRIPTION
This caused the LICENSE file to not be in distributions.