### PR TITLE
Fix old tag paths not properly getting disposed during save_tag_as

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This project also inherits changes from [Binilla](https://github.com/Sigmmma/binilla).
 
-## [Unreleased]
+## [1.9.1]
 ### Changed
  - Fix missing license in distributions.
+ - Fix old tag paths not properly getting disposed during save_as events. (This bug made it so that you couldn't reopen a tag right after having opened and saved it to different file using save_as)
 
 ## [1.9.0]
 ### Added

--- a/mozzarilla/__init__.py
+++ b/mozzarilla/__init__.py
@@ -12,6 +12,6 @@
 # ##############
 __author__ = "Devin Bobadilla, Michelle van der Graaf"
 #           YYYY.MM.DD
-__date__ = "2020.02.29"
-__version__ = (1, 9, 0)
+__date__ = "2020.03.07"
+__version__ = (1, 9, 1)
 __website__ = "https://github.com/Sigmmma/mozzarilla"

--- a/mozzarilla/app_window.py
+++ b/mozzarilla/app_window.py
@@ -918,6 +918,8 @@ class Mozzarilla(Binilla):
                 return
             tag = self.selected_tag
 
+        old_filepath = tag.filepath
+
         if not hasattr(tag, "serialize"):
             return
 
@@ -961,6 +963,10 @@ class Mozzarilla(Binilla):
         except Exception:
             print(format_exc())
             raise IOError("Could not save: %s" % filepath)
+
+        if old_filepath != filepath:
+            tag.handler.delete_tag(filepath=old_filepath)
+            tag.filepath = filepath
 
         self.update_tag_window_title(w)
         return tag


### PR DESCRIPTION
This bug made it so that you couldn't reopen a tag right after having opened and saved it to different file using save_as.