### PR TITLE
Fix hmt encoding

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This project also inherits changes from [Binilla](https://github.com/Sigmmma/binilla).
 
+## [1.9.2]
+### Changed
+ - Fix encoding problems with hmt files that aren't utf-16-le encoded.
+
 ## [1.9.1]
 ### Changed
  - Fix missing license in distributions.

--- a/mozzarilla/__init__.py
+++ b/mozzarilla/__init__.py
@@ -10,8 +10,8 @@
 # ##############
 #   metadata   #
 # ##############
-__author__ = "Devin Bobadilla, Michelle van der Graaf"
+__author__ = "Sigmmma"
 #           YYYY.MM.DD
-__date__ = "2020.03.07"
-__version__ = (1, 9, 1)
+__date__ = "2020.04.28"
+__version__ = (1, 9, 2)
 __website__ = "https://github.com/Sigmmma/mozzarilla"

--- a/mozzarilla/windows/tools/compile_hud_message_text.py
+++ b/mozzarilla/windows/tools/compile_hud_message_text.py
@@ -44,7 +44,11 @@ def hud_message_text_from_hmt(app, fp=None):
 
         print("Creating hud_message_text from this hmt file:")
         print("    %s" % fp)
-        with fp.open("r", encoding="utf-16-le") as f:
+        # Encoding here used to be "utf-16-le".
+        # However Python and our libraries are smart enough to handle the
+        # encoding conversion for us. So, we can avoid user bugs by not
+        # force interpreting this file as anything specific.
+        with fp.open("r") as f:
             hmt_string_data = f.read()
     except Exception:
         print(format_exc())

--- a/mozzarilla/windows/tools/compile_hud_message_text.py
+++ b/mozzarilla/windows/tools/compile_hud_message_text.py
@@ -50,7 +50,7 @@ def hud_message_text_from_hmt(app, fp=None):
             contents = f.read()
             guess = charset_normalizer.detect(contents)
             # utf-16 is our fallback as that is the proper encoding for
-            # these files and has the biggest failure rate for detection
+            # these files and has the biggest detection failure rate.
             hmt_string_data = contents.decode(guess['encoding'] or "utf-16")
             # Reading files this way doesn't remove carriage returns.
             # We have to wipe them out like this.

--- a/mozzarilla/windows/tools/compile_hud_message_text.py
+++ b/mozzarilla/windows/tools/compile_hud_message_text.py
@@ -46,11 +46,12 @@ def hud_message_text_from_hmt(app, fp=None):
         print("Creating hud_message_text from this hmt file:")
         print("    %s" % fp)
 
-        encoding = "utf-16-le"
         with fp.open("rb") as f:
             contents = f.read()
             guess = charset_normalizer.detect(contents)
-            hmt_string_data = contents.decode(guess['encoding'])
+            # utf-16 is our fallback as that is the proper encoding for
+            # these files and has the biggest failure rate for detection
+            hmt_string_data = contents.decode(guess['encoding'] or "utf-16")
             # Reading files this way doesn't remove carriage returns.
             # We have to wipe them out like this.
             hmt_string_data = hmt_string_data.replace("\r", "")

--- a/mozzarilla/windows/tools/compile_hud_message_text.py
+++ b/mozzarilla/windows/tools/compile_hud_message_text.py
@@ -8,6 +8,7 @@
 #
 
 import os
+import charset_normalizer
 
 from pathlib import Path
 from traceback import format_exc
@@ -44,12 +45,16 @@ def hud_message_text_from_hmt(app, fp=None):
 
         print("Creating hud_message_text from this hmt file:")
         print("    %s" % fp)
-        # Encoding here used to be "utf-16-le".
-        # However Python and our libraries are smart enough to handle the
-        # encoding conversion for us. So, we can avoid user bugs by not
-        # force interpreting this file as anything specific.
-        with fp.open("r") as f:
-            hmt_string_data = f.read()
+
+        encoding = "utf-16-le"
+        with fp.open("rb") as f:
+            contents = f.read()
+            guess = charset_normalizer.detect(contents)
+            hmt_string_data = contents.decode(guess['encoding'])
+            # Reading files this way doesn't remove carriage returns.
+            # We have to wipe them out like this.
+            hmt_string_data = hmt_string_data.replace("\r", "")
+
     except Exception:
         print(format_exc())
         print("    Could not load hmt file.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ supyr_struct
 binilla
 reclaimer
 arbytmap
+charset_normalizer

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ setup(
         },
     platforms=["POSIX", "Windows"],
     keywords=["binilla", "binary", "data structure"],
-    install_requires=['reclaimer', 'binilla', 'arbytmap', 'supyr_struct'],
-    requires=['reclaimer', 'arbytmap', 'binilla'],
+    install_requires=['reclaimer', 'binilla', 'arbytmap', 'supyr_struct', "charset_normalizer"],
+    requires=['reclaimer', 'arbytmap', 'binilla', "charset_normalizer"],
     provides=['mozzarilla'],
     python_requires=">=3.5",
     classifiers=[


### PR DESCRIPTION
Reported issue:
```
    Could not load hmt file.
Creating hud_message_text from this hmt file:
    C:\Users\kianh\OneDrive\Documents\camo_function.hmt
    WARNING: Message name on line 1 is too long. Truncating name to '扯彪慣潭敲档牡楧杮㴠䌠浡⁯敲档牡楧杮⸮മ漊橢损浡牯慥祤㴠䌠浡⁯'
    ERROR: No name or message on line 1
```